### PR TITLE
Bug fix. doFinal only calculates SHA256 correctly the first time.

### DIFF
--- a/Crypto.cpp
+++ b/Crypto.cpp
@@ -107,6 +107,11 @@ static const byte sha256_padding[64] =
  */
 SHA256::SHA256()
 {
+    this->reset();
+}
+
+void SHA256::reset() 
+{
     total[0] = 0;
     total[1] = 0;
     state[0] = 0x6A09E667;
@@ -322,6 +327,7 @@ void SHA256::doFinal(byte *digest)
 #if defined ESP8266
     ESP.wdtFeed();
 #endif
+    this->reset(); // Reset the internals, so we can calculate the next hash!
 }
 
 bool SHA256::matches(const byte *expected)

--- a/Crypto.h
+++ b/Crypto.h
@@ -51,6 +51,10 @@ class SHA256
          */
         bool matches(const byte *expected);
     private:
+        /**
+         * Resets the internals of the class to compute a new correct hash! 
+         */
+        void reset();
         void SHA256_Process(const byte digest[64]);
         uint32_t total[2];
         uint32_t state[8];


### PR DESCRIPTION
One of the issues is that the doFinal function calculates only the correct SHA256 the first time. After that, the hashes are wrong. The problem is that the state variables of the classes are not resetted. Therefore, doFinal calculate the next hash using the wrong state values. I have fix this by adding a reset function, that resets these state variables. At the end of doFinal the reset method is called and all next hashes are correctly calculated!

I hope you like this fix!